### PR TITLE
Create top-level bulk.yml containing the import options

### DIFF
--- a/bulk.yml
+++ b/bulk.yml
@@ -1,0 +1,12 @@
+---
+continue: "true"
+transfer: "ln_s"
+exclude: "clientpath"
+checksum_algorithm: "File-Size-64"
+logprefix: "logs/"
+output: "yaml"
+# Default columns for the regular screens.
+# This may need to be modified in other bulk files.
+columns:
+    - target
+    - path

--- a/experimentA/idr0042-experimentA-bulk.yml
+++ b/experimentA/idr0042-experimentA-bulk.yml
@@ -1,6 +1,3 @@
 ---
-include: "../../bulk.yml"
+include: "../bulk.yml"
 path: "idr0042-experimentA-filePaths.tsv"
-columns:
-    - target
-    - path


### PR DESCRIPTION
With the decoupling of the study metadata files, this removes the remaining coupling with the upstream `idr-metadata`.

With this change, it should be possible to run the import/annotation workflow from the study repo i.e.

```
git clone https://github.com/IDR/idr0042-nirschl-wsideeplearning
cd idr0042-nirschl-wsideeplearning/experimentA
bin/omero import --bulk idr0042-experimentA-bulk.yml
...
```

The integration of each study repository as a submodule the `idr-metadata`  will still remain in the overall process (esp. for tagging releases) but is no longer a requirement for testing.

/cc @joshmoore @dominikl @pwalczysko @manics 