### PR TITLE
Add primary_group_keys to bulkmap config

### DIFF
--- a/experimentA/idr0042-experimentA-bulkmap-config.yml
+++ b/experimentA/idr0042-experimentA-bulkmap-config.yml
@@ -59,3 +59,10 @@ columns:
         - name: Characteristics [Organism]
           clientname: Organism
           include: yes
+
+advanced:
+  ignore_missing_primary_key: yes
+  primary_group_keys:
+    - namespace: openmicroscopy.org/mapr/organism
+      keys:
+        - Organism


### PR DESCRIPTION
This should prevent the organism map annotation to be duplicated when populating the images.

All the primary keys annotation from `idr0040`, `idr0041`, `idr0042` and `idr0045` should have been deleted from `test52` and `idr0042` organism map annotations should have been re-annotated with this PR.

To test it via the UI:
- open a few images on `test52` and check the map annotations are identical to the ones for the same images in production IDR
- hover over a few organism annotations and check the ID is the same across all images
- in the top-level Organism menu, click on `Homo Sapiens`, check that only one annotation displays in the right-hand panel and check that `idr0042` is in the list of results


See also https://github.com/IDR/idr0041-cai-mitoticatlas/pull/15